### PR TITLE
Update Pronto

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mix archive.install
 
 To install credo (globally):
 ```
-git clone https://github.com/dlpil/credo
+git clone https://github.com/rrrene/credo
 cd credo
 mix archive.build
 mix archive.install

--- a/pronto-credo.gemspec
+++ b/pronto-credo.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
 
-  spec.add_runtime_dependency 'pronto', '~> 0.5.0'
+  spec.add_runtime_dependency 'pronto', '~> 0.6.0'
 end


### PR DESCRIPTION
Hi @carakan, this PR updates Pronto to `0.6.0` (the latest version) and corrects a mistake in the README.
