### PR TITLE
Support Pronto 0.6

### DIFF
--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -3,10 +3,14 @@ require 'pronto/credo/wrapper'
 
 module Pronto
   class CredoRunner < Runner
-    def run(patches, _)
-      return [] unless patches
+    def initialize(_, _)
+      super
+    end
 
-      patches.select { |p| p.additions > 0 }
+    def run
+      return [] unless @patches
+
+      @patches.select { |p| p.additions > 0 }
         .select { |p| elixir_file?(p.new_file_full_path) }
         .map { |p| inspect(p) }
         .flatten

--- a/pronto-credo.gemspec
+++ b/pronto-credo.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
 
-  spec.add_runtime_dependency 'pronto', '~> 0.5.0'
+  spec.add_runtime_dependency 'pronto', '~> 0.6.0'
 end


### PR DESCRIPTION
Hi again @carakan 👋  This PR updates `pronto-credo` to support the latest and greatest, Pronto v0.6
