### PR TITLE
Don't use full-path when passing it to Credo

### DIFF
--- a/lib/pronto/credo/version.rb
+++ b/lib/pronto/credo/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module Credo
-    VERSION = "0.0.4".freeze
+    VERSION = "0.0.5-dev-ps".freeze
   end
 end

--- a/lib/pronto/credo/wrapper.rb
+++ b/lib/pronto/credo/wrapper.rb
@@ -12,7 +12,7 @@ module Pronto
 
       def lint
         return [] if patch.nil?
-        path = patch.new_file_full_path.to_s
+        path = patch.delta.new_file[:path]
         stdout, stderr, _ = Open3.capture3(credo_executable(path))
         puts "WARN: pronto-credo: #{stderr}" if stderr && stderr.size > 0
         return {} if stdout.nil? || stdout == 0

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -26,7 +26,7 @@ module Pronto
       offences.each do |offence|
         messages += patch
           .added_lines
-          .select { |line| line.new_lineno == offence[:line] }
+          .select { |line| close_to(line.new_lineno, offence[:line]) }
           .map { |line| new_message(offence, line) }
       end
 
@@ -40,6 +40,10 @@ module Pronto
 
     def elixir_file?(path)
       %w(.ex .exs).include?(File.extname(path))
+    end
+
+    def close_to(diff_line, offence_line)
+      (diff_line - offence_line).abs < 2
     end
   end
 end

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -43,7 +43,15 @@ module Pronto
 
     def new_message(offence, line)
       path = line.patch.delta.new_file[:path]
-      Message.new(path, line, offence[:level], offence[:message])
+      # update the Line to have the correct line number
+      # TODO it'd be great to have a real way to do this.
+      rugged_line = line.line.clone
+      rugged_line.instance_exec {
+        @new_lineno = offence[:line]
+      }
+      new_line = line.clone
+      new_line.line = rugged_line
+      Message.new(path, new_line, offence[:level], offence[:message])
     end
 
     def elixir_file?(path)

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -24,13 +24,21 @@ module Pronto
       messages = []
 
       offences.each do |offence|
-        messages += patch
-          .added_lines
-          .select { |line| close_to(line.new_lineno, offence[:line]) }
-          .map { |line| new_message(offence, line) }
+        added_lines = patch.added_lines
+        bad_lines =
+          added_lines
+            .select { |line| line.new_lineno == offence[:line] }
+
+        if bad_lines == []
+          bad_lines =
+            added_lines
+              .select { |line| close_to(line.new_lineno, offence[:line]) }
+        end
+
+        messages += bad_lines.map { |line| new_message(offence, line) }
       end
 
-      messages.compact
+      messages
     end
 
     def new_message(offence, line)


### PR DESCRIPTION
Credo seems to check the whole repository when a full path is given to it.  This PR changes that to only pass the relative path.

It additionally relaxes the check for line numbers: this allows it to catch changes like "pipe chain should start with a raw value" which tend to be triggered by different line from what's in the patch.