### PR TITLE
A fix and a feature

### DIFF
--- a/lib/pronto/credo/output_parser.rb
+++ b/lib/pronto/credo/output_parser.rb
@@ -17,8 +17,8 @@ module Pronto
 
       def parse
         output.lines.map do |line|
-          next unless line.start_with?(file)
           line_parts = line.split(':')
+          next unless file.start_with?(line_parts[0])
           offence_in_line = line_parts[1]
           column_line = nil
           if line_parts[2].to_i == 0

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -10,6 +10,8 @@ module Pronto
     def run
       return [] unless @patches
 
+      compile
+
       @patches.select { |p| p.additions > 0 }
         .select { |p| elixir_file?(p.new_file_full_path) }
         .map { |p| inspect(p) }
@@ -18,6 +20,11 @@ module Pronto
     end
 
     private
+
+    def compile
+      _, _, status = Open3.capture3("mix deps.get && mix compile --force")
+      raise "failed to compile" unless status.success?
+    end
 
     def inspect(patch)
       offences = Credo::Wrapper.new(patch).lint

--- a/spec/pronto/credo/output_parser_spec.rb
+++ b/spec/pronto/credo/output_parser_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Pronto::Credo::OutputParser do
   describe '#parse' do
     subject { parser.parse }
     it 'parses output' do
-      puts(subject)
       expect(subject).to eq(
         [
           { line: 30,


### PR DESCRIPTION
Howdy @carakan!  I've been using Pronto as part of [Nag](https://github.com/doomspork/nag) and I noticed that while our Ruby and JavaScript reported errors we weren't seeing any for Elixir even when Credo would report them locally.  I looked into it and I found two problems:

1) The `OutputParser` does a path comparison and these paths don't match
2) The project has to be compiled before we can proceed.  If you're running Pronto locally this isn't an issue but relying on something Nag makes it a bit trickier.

To fix these two aforementioned problems I made some changes:

1) Switched up the path comparison so we look for the fragment in the full path
2) Run `mix deps.get && mix compile --force` before we kick off `credo`

Would love to get your thoughts when you have a moment 👍 
