### PR TITLE
make compilation an environmental flag, not the default

### DIFF
--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -10,7 +10,7 @@ module Pronto
     def run
       return [] unless @patches
 
-      compile if ENV["PRONTO_CREDO_COMPILE"]
+      compile if ENV["PRONTO_CREDO_COMPILE"] == 1
 
       @patches.select { |p| p.additions > 0 }
         .select { |p| elixir_file?(p.new_file_full_path) }

--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -10,7 +10,7 @@ module Pronto
     def run
       return [] unless @patches
 
-      compile
+      compile if ENV["PRONTO_CREDO_COMPILE"]
 
       @patches.select { |p| p.additions > 0 }
         .select { |p| elixir_file?(p.new_file_full_path) }


### PR DESCRIPTION
Our CI runs are slowing down unnecessarily because of the compilation step.  

In our case, compilation is actually unneeded because we `mix do deps.get, compile` earlier in the build.

Could we switch to having an environmental flag to toggle this?