### PR TITLE
Allow all messages to return non-zero status with --exit-code flag

### DIFF
--- a/lib/pronto/credo/output_parser.rb
+++ b/lib/pronto/credo/output_parser.rb
@@ -2,17 +2,30 @@ module Pronto
   module Credo
     class OutputParser
       attr_reader :output, :file
-      TYPE_WARNINGS = { 'R' => :info,
-                        'W' => :warning,
-                        'C' => :info,
-                        'D' => :info,
-                        'F' => :info,
-                        'A' => :info
-                      }
 
       def initialize(file, output)
         @file = file
         @output = output
+      end
+
+      def type_warnings
+        @type_warnings ||= if ENV["PRONTO_CREDO_STRICT"] == "1"
+          { 'R' => :warning,
+            'W' => :warning,
+            'C' => :warning,
+            'D' => :warning,
+            'F' => :warning,
+            'A' => :warning
+          }
+        else
+          { 'R' => :info,
+            'W' => :warning,
+            'C' => :info,
+            'D' => :info,
+            'F' => :info,
+            'A' => :info
+          }
+        end
       end
 
       def parse
@@ -22,10 +35,10 @@ module Pronto
           offence_in_line = line_parts[1]
           column_line = nil
           if line_parts[2].to_i == 0
-            offence_level = TYPE_WARNINGS[line_parts[2].strip]
+            offence_level = type_warnings[line_parts[2].strip]
             offence_message = line_parts[3..-1].join(':').strip
           else
-            offence_level = TYPE_WARNINGS[line_parts[3].strip]
+            offence_level = type_warnings[line_parts[3].strip]
             column_line = line_parts[2].to_i
             offence_message = line_parts[4..-1].join(':').strip
           end


### PR DESCRIPTION
At the moment when I run `pronto run --exit-code` it creates new comments but not all of them makes build to fail.

With this PR it will be possible to run
`PRONTO_CREDO_STRICT=1 pronto run --exit-code`
It will return non-zero status code for any credo message.