### PR TITLE
Output the error messages when the elixir application fails to compile

### DIFF
--- a/lib/pronto/credo_runner.rb
+++ b/lib/pronto/credo_runner.rb
@@ -22,8 +22,12 @@ module Pronto
     private
 
     def compile
-      _, _, status = Open3.capture3("mix deps.get && mix compile --force")
-      raise "failed to compile" unless status.success?
+      stdout_stderr, status = Open3.capture2e("mix deps.get && mix compile --force")
+      if !status.success?
+        $stderr.puts "Elixir compilation error(s):"
+        $stderr.puts stdout_stderr
+        raise "failed to compile"
+      end
     end
 
     def inspect(patch)


### PR DESCRIPTION
I'm running pronto-credo from within a docker container so it was difficult to diagnose why my app was failing to compile (missing dependencies or system libraries).